### PR TITLE
Add originquery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM sentriz/betanin:latest
 LABEL org.opencontainers.image.source https://github.com/medvid/docker-betanin
 
-RUN pip3 install --no-cache-dir jsonpath_rw python3-discogs-client drop2beets beetcamp beets-copyartifacts3 beets-follow
+RUN pip3 install --no-cache-dir jsonpath_rw python3-discogs-client 
+RUN pip3 install --no-cache-dir beetcamp beets-copyartifacts3 beets-follow drop2beets
+RUN pip3 install --no-cache-dir git+https://github.com/x1ppy/beets-originquery

--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ A Dockerfile for [Betanin](https://github.com/sentriz/betanin) with extra beets 
   * [beets-copyartifacts3](https://github.com/sbarakat/beets-copyartifacts): helps bring non-music files along during import.
   * [beets-follow](https://github.com/nolsto/beets-follow): lets you check for new albums from artists you like.
   * [drop2beets](https://github.com/martinkirch/drop2beets): imports singles as soon as they are dropped in a folder.
+  * [beets-originquery](https://github.com/x1ppy/beets-originquery): uses supplemental files in imported directories to improve MusicBrainz matches for untagged data.


### PR DESCRIPTION
Add beets-originquery, a plugin for beets that uses supplemental files in imported directories to improve MusicBrainz matches for untagged data.